### PR TITLE
fix 2d文字纹理集超出宽高上限，clearTexture无效

### DIFF
--- a/src/core/text/DynamicFont.ts
+++ b/src/core/text/DynamicFont.ts
@@ -95,7 +95,7 @@ export class DynamicFont {
 
     private clearTexture(): void {
         this._context.fillStyle = 'black';
-        this._context.fillRect(0, 0, this._canvas.width, this._canvas.height);
+        this._context.clearRect(0, 0, this._canvas.width, this._canvas.height);
         this._context.globalCompositeOperation = "lighter";
 
         for (let i = 0; i < 3; i++)


### PR DESCRIPTION
2d文字离屏canvas纹理集超出宽高上限 ，导致文字重复filltext，clearTexture无效
![192.168.68.214_8000__iPhone X_.png](https://i.loli.net/2021/03/08/aHo2xwUfkO8ed9i.png)