### PR TITLE
使用WebGL2Renderer时，glsl存在新增保留关键词:【filter】导致解析报错

### DIFF
--- a/src/core/NMaterial.ts
+++ b/src/core/NMaterial.ts
@@ -60,7 +60,7 @@ export class NMaterial extends ShaderMaterial {
 
         this.fragmentShader = `
         uniform bool grayed;
-        uniform bool filter;
+        uniform bool colorFilter;
         uniform mat4 colorMatrix;
         uniform vec4 colorOffset;
 


### PR DESCRIPTION
uniform bool filter;

Illegal use of reserved word

see : https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.4.00.pdf