### PR TITLE
使用【gulp-replace】插件针对不同版本的three的接口兼容

### DIFF
--- a/migrationRules.js
+++ b/migrationRules.js
@@ -1,0 +1,27 @@
+// #Migration see https://github.com/mrdoob/three.js/wiki/Migration-Guide
+const currentVersion = "116"
+const rules = {
+    "123": [
+        {
+            type: "string",
+            pattern: ".inverse()",
+            replacement: ".invert()"
+        },
+        {
+            type: "regex",
+            pattern:".getInverse\\(([^]+?)\\);",
+            replacement: ".copy($1).invert();"
+        }
+    ]
+};
+
+const getMigrationRules = (version, rules) => {
+    let rule = [];
+    for (let key in rules) {
+        if (+key >= +version) {
+            rule.push(...rules[key]);
+        }
+    }
+    return rule;
+}
+module.exports = getMigrationRules(currentVersion, rules);

--- a/migrationRules.js
+++ b/migrationRules.js
@@ -10,7 +10,7 @@ const rules = {
         },
         {
             type: "regex",
-            pattern:".getInverse\\(([^]+?)\\);",
+            pattern: ".getInverse\\(([^]+?)\\);",
             replacement: ".copy($1).invert();"
         }
     ]
@@ -18,11 +18,14 @@ const rules = {
 
 const getMigrationRules = (version, rules) => {
     let rule = [];
-    for (let key in rules) {
-        if (+key >= +version) {
-            rule.push(...rules[key]);
+    if (+currentVersion > +initalVersion) {
+        for (let key in rules) {
+            if (+key >= +version) {
+                rule.push(...rules[key]);
+            }
         }
     }
     return rule;
 }
+
 module.exports = getMigrationRules(currentVersion, rules);

--- a/migrationRules.js
+++ b/migrationRules.js
@@ -1,5 +1,6 @@
 // #Migration see https://github.com/mrdoob/three.js/wiki/Migration-Guide
-const currentVersion = "116"
+const initalVersion = "116"; // fairygui启动时的three版本
+const currentVersion = "126"; // 项目工程使用的three版本
 const rules = {
     "123": [
         {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "gulp-concat": "^2.6.1",
     "gulp-minify": "^3.1.0",
     "gulp-rename": "^2.0.0",
+    "gulp-replace": "^1.1.3",
     "gulp-typescript": "^3.1.6",
     "gulp-uglify": "^3.0.2",
     "gulp-uglify-es": "^2.0.0",


### PR DESCRIPTION
因three版本迭代较快，接口API常更新变换或废弃，导致在渲染的时候打印过多warn
fgui是基于r116进行编写的，使用【gulp-replace】插件针对不同版本的three的接口在打包的时候进行替换兼容。
[参考地址](https://github.com/mrdoob/three.js/wiki/Migration-Guide)