### PR TITLE
fix 字体变粗&色差 bug

### DIFF
--- a/src/core/NMaterial.ts
+++ b/src/core/NMaterial.ts
@@ -1,4 +1,4 @@
-import { ShaderMaterial, ShaderLib, UniformsUtils, Uniform, Matrix4, Vector4, Texture, DoubleSide, DepthModes } from "three";
+import { ShaderMaterial, ShaderLib, UniformsUtils, Uniform, Matrix4, Vector4, Texture, DoubleSide, DepthModes,Color } from "three";
 
 export class NMaterial extends ShaderMaterial {
     public map: Texture;
@@ -9,7 +9,12 @@ export class NMaterial extends ShaderMaterial {
         let customUniforms = UniformsUtils.merge([
             ShaderLib.basic.uniforms,
             { _ColorMatrix: new Uniform(new Matrix4()) },
-            { _ColorOffset: new Uniform(new Vector4()) }
+            { _ColorOffset: new Uniform(new Vector4()) },
+            {
+                diffuse: {
+                    value: new Color(0xffffff)
+                }
+            }
         ]);
 
         this.uniforms = customUniforms;

--- a/src/core/text/DynamicFont.ts
+++ b/src/core/text/DynamicFont.ts
@@ -96,6 +96,7 @@ export class DynamicFont {
     private clearTexture(): void {
         this._context.fillStyle = 'black';
         this._context.clearRect(0, 0, this._canvas.width, this._canvas.height);
+        this._context.fillRect(0, 0, this._canvas.width, this._canvas.height);
         this._context.globalCompositeOperation = "lighter";
 
         for (let i = 0; i < 3; i++)


### PR DESCRIPTION
- clearRect清空文字图集后需要再fillRect；
- THREE源码默认diffuse是0xeeeeee，导致UI场景出现色差问题，r129已调整默认为白色[see](https://github.com/mrdoob/three.js/commit/35eaf1906fb74f16be8b155c86c1e0d8a1d4669c#diff-d508a837567db31e767ebb45113fb66e42cb0f786aa22d3d84ddce93a564dfbd)