### PR TITLE
fixed: renderer toneMapping & outputEncoding cause discoloration

### DIFF
--- a/src/core/NMaterial.ts
+++ b/src/core/NMaterial.ts
@@ -159,6 +159,8 @@ export class NMaterial extends ShaderMaterial {
         this.transparent = true;
         this.depthTest = false;
         this.side = DoubleSide;
+        this.toneMapped = false;
+        this.encoding = THREE.LinearEncoding;
         //this.wireframe = true;
         this["isMeshBasicMaterial"] = true;
     }


### PR DESCRIPTION
真实性渲染中对renderer的两个选项会引起UI整体偏色